### PR TITLE
Fix: CVE-2024-42471

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -72,13 +72,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download Terraform Plan Output
-        uses: actions/download-artifact@4.1.7
+        uses: actions/download-artifact@v4.1.7
         with:
           name: plan-file-dev
           path: tf-plan-files/
 
       - name: Download Terraform Plan Output
-        uses: actions/download-artifact@4.1.7
+        uses: actions/download-artifact@v4.1.7
         with:
           name: plan-file-prod
           path: tf-plan-files/

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -72,13 +72,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download Terraform Plan Output
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@4.1.7
         with:
           name: plan-file-dev
           path: tf-plan-files/
 
       - name: Download Terraform Plan Output
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@4.1.7
         with:
           name: plan-file-prod
           path: tf-plan-files/

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -53,7 +53,7 @@ jobs:
           output: plan-${{ matrix.env }}.json
 
       - name: Upload Terraform Plan Output
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: plan-file-${{ matrix.env }}
           path: plan-${{ matrix.env }}.json


### PR DESCRIPTION
# what 
Versions of actions/download-artifact before 4.1.7 are vulnerable to arbitrary file write when downloading and extracting a specifically crafted artifact that contains path traversal filenames.

